### PR TITLE
"distance" option

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -323,6 +323,9 @@
 				nextEl = dragEl.nextSibling;
 				activeGroup = options.group;
 
+				this._lastX = evt.clientX;
+				this._lastY = evt.clientY;
+
 				dragStartFn = function () {
 					// Delayed drag has been triggered
 					// we can re-enable the events: touchmove/mousemove
@@ -463,6 +466,15 @@
 
 
 		_onTouchMove: function (/**TouchEvent*/evt) {
+
+			if (this.options.distance && this.options.distance > 0) {
+				// sorting will not start until mouse is dragged at a minimum distance
+				// this is used to prevent unwanted move during a simple click on a sortable element
+				if (!Sortable.active && !(Math.abs(evt.clientX - this._lastX) > this.options.distance || Math.abs(evt.clientY - this._lastY) > this.options.distance)) {
+					return;
+				}
+			}
+
 			if (tapEvt) {
 				// only set the status to dragging, when we are actually dragging
 				if (!Sortable.active) {


### PR DESCRIPTION
An attempt to implement the "distance" option (like http://api.jqueryui.com/sortable/#option-distance).
This is useful when your sortable element is also clickable. This prevents the drag to begin due to a micro-movement when you click.
